### PR TITLE
Add V7 Compatibility Layouts

### DIFF
--- a/addon/build.gradle
+++ b/addon/build.gradle
@@ -14,6 +14,9 @@ configurations {
 }
 
 dependencies{
+  compile     "com.vaadin:vaadin-compatibility-server:${vaadin.version}"
+  compile     "com.vaadin:vaadin-compatibility-client:${vaadin.version}"
+  compile     "com.vaadin:vaadin-compatibility-shared:${vaadin.version}"
   testCompile 'junit:junit:4.8.+'
   deploy      'org.apache.maven.wagon:wagon-ssh:2.2'
 }
@@ -23,6 +26,7 @@ vaadinCompile {
     // Starting from IE11 permutation is the same as for gecko1_8
     userAgent 'gecko1_8,safari'
     widgetset 'fi.jasoft.dragdroplayouts.DragDropLayoutsWidgetSet'
+    sourcePaths 'client', 'v7/client'
 }    
 
 vaadin {    

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/v7/DDHorizontalLayout.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/v7/DDHorizontalLayout.java
@@ -1,0 +1,326 @@
+/*
+ * Copyright 2015 John Ahlroos
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package fi.jasoft.dragdroplayouts.v7;
+
+import java.util.Map;
+
+import com.vaadin.event.Transferable;
+import com.vaadin.event.dd.DropHandler;
+import com.vaadin.event.dd.DropTarget;
+import com.vaadin.event.dd.TargetDetails;
+import com.vaadin.event.dd.TargetDetailsImpl;
+import com.vaadin.server.PaintException;
+import com.vaadin.server.PaintTarget;
+import com.vaadin.shared.MouseEventDetails;
+import com.vaadin.shared.ui.dd.HorizontalDropLocation;
+import com.vaadin.ui.Component;
+import com.vaadin.v7.ui.HorizontalLayout;
+import com.vaadin.ui.LegacyComponent;
+
+import fi.jasoft.dragdroplayouts.DDUtil;
+import fi.jasoft.dragdroplayouts.client.ui.Constants;
+import fi.jasoft.dragdroplayouts.client.ui.LayoutDragMode;
+import fi.jasoft.dragdroplayouts.v7.client.ui.horizontallayout
+        .DDHorizontalLayoutState;
+import fi.jasoft.dragdroplayouts.client.ui.util.IframeCoverUtility;
+import fi.jasoft.dragdroplayouts.events.LayoutBoundTransferable;
+import fi.jasoft.dragdroplayouts.interfaces.DragFilter;
+import fi.jasoft.dragdroplayouts.interfaces.DragFilterSupport;
+import fi.jasoft.dragdroplayouts.interfaces.DragImageProvider;
+import fi.jasoft.dragdroplayouts.interfaces.DragImageReferenceSupport;
+import fi.jasoft.dragdroplayouts.interfaces.LayoutDragSource;
+import fi.jasoft.dragdroplayouts.interfaces.ShimSupport;
+
+/**
+ * Horizontal layout with drag and drop support
+ * 
+ * @author John Ahlroos / www.jasoft.fi
+ * @since 0.4.0
+ */
+@SuppressWarnings("serial")
+public class DDHorizontalLayout extends HorizontalLayout
+        implements LayoutDragSource, DropTarget, ShimSupport, LegacyComponent,
+        DragFilterSupport, DragImageReferenceSupport {
+
+    /**
+     * The drop handler which handles dropped components in the layout.
+     */
+    private DropHandler dropHandler;
+
+    // A filter for dragging components.
+    private DragFilter dragFilter = DragFilter.ALL;
+
+    private DragImageProvider dragImageProvider;
+
+    /**
+     * Contains the component over which the drop was made and the index on
+     * which the drop was made.
+     */
+    public class HorizontalLayoutTargetDetails extends TargetDetailsImpl {
+
+        private Component over;
+
+        private int index = -1;
+
+        protected HorizontalLayoutTargetDetails(
+                Map<String, Object> rawDropData) {
+            super(rawDropData, DDHorizontalLayout.this);
+
+            // Get over which component (if any) the drop was made and the
+            // index of it
+            if (getData(Constants.DROP_DETAIL_TO) != null) {
+                index = Integer
+                        .valueOf(getData(Constants.DROP_DETAIL_TO).toString());
+                if (index >= 0 && index < components.size()) {
+                    over = components.get(index);
+                }
+            }
+
+            // Was the drop over no specific cell
+            if (over == null) {
+                over = DDHorizontalLayout.this;
+            }
+        }
+
+        /**
+         * The component over which the drop was made.
+         * 
+         * @return Null if the drop was not over a component, else the component
+         */
+        public Component getOverComponent() {
+            return over;
+        }
+
+        /**
+         * The index over which the drop was made. If the drop was not made over
+         * any component then it returns -1.
+         * 
+         * @return The index of the component or -1 if over no component.
+         */
+        public int getOverIndex() {
+            return index;
+        }
+
+        /**
+         * Some details about the mouse event
+         * 
+         * @return details about the actual event that caused the event details.
+         *         Practically mouse move or mouse up.
+         */
+        public MouseEventDetails getMouseEvent() {
+            return MouseEventDetails.deSerialize(
+                    getData(Constants.DROP_DETAIL_MOUSE_EVENT).toString());
+        }
+
+        /**
+         * Get the horizontal position of the dropped component within the
+         * underlying cell.
+         * 
+         * @return The drop location
+         */
+        public HorizontalDropLocation getDropLocation() {
+            if (getData(
+                    Constants.DROP_DETAIL_HORIZONTAL_DROP_LOCATION) != null) {
+                return HorizontalDropLocation.valueOf(
+                        getData(Constants.DROP_DETAIL_HORIZONTAL_DROP_LOCATION)
+                                .toString());
+            } else {
+                return null;
+            }
+        }
+    }
+
+    /**
+     * Construct a new horizontal layout
+     */
+    public DDHorizontalLayout() {
+        super();
+    }
+
+    /**
+     * Construct a new horizontal layout with children
+     * 
+     * @param components
+     *            the child components to add
+     */
+    public DDHorizontalLayout(Component... components) {
+        super(components);
+    }
+
+    /**
+     * {@inheritDoc}
+     * 
+     */
+    public void paintContent(PaintTarget target) throws PaintException {
+
+        if (dropHandler != null && isEnabled()) {
+            dropHandler.getAcceptCriterion().paint(target);
+        }
+
+        // Drop ratios
+        target.addAttribute(Constants.ATTRIBUTE_HORIZONTAL_DROP_RATIO,
+                getState().cellLeftRightDropRatio);
+
+        // Drag mode
+        if (isEnabled()) {
+            target.addAttribute(Constants.DRAGMODE_ATTRIBUTE,
+                    getState().ddState.dragMode.ordinal());
+        } else {
+            target.addAttribute(Constants.DRAGMODE_ATTRIBUTE,
+                    LayoutDragMode.NONE.ordinal());
+        }
+
+        // Shims
+        target.addAttribute(IframeCoverUtility.SHIM_ATTRIBUTE,
+                getState().ddState.iframeShims);
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see
+     * com.vaadin.event.dd.DropTarget#translateDropTargetDetails(java.util.Map)
+     */
+    public TargetDetails translateDropTargetDetails(
+            Map<String, Object> clientVariables) {
+        return new HorizontalLayoutTargetDetails(clientVariables);
+    }
+
+    /**
+     * Get the transferable created by a drag event.
+     */
+    public Transferable getTransferable(Map<String, Object> rawVariables) {
+        return new LayoutBoundTransferable(this, rawVariables);
+    }
+
+    /**
+     * Returns the drop handler which handles drop events from dropping
+     * components on the layout. Returns Null if dropping is disabled.
+     */
+    public DropHandler getDropHandler() {
+        return dropHandler;
+    }
+
+    /**
+     * Sets the current handler which handles dropped components on the layout.
+     * By setting a drop handler dropping components on the layout is enabled.
+     * By setting the dropHandler to null dropping is disabled.
+     * 
+     * @param dropHandler
+     *            The drop handler to handle drop events or null to disable
+     *            dropping
+     */
+    public void setDropHandler(DropHandler dropHandler) {
+        DDUtil.verifyHandlerType(this, dropHandler);
+        if (this.dropHandler != dropHandler) {
+            this.dropHandler = dropHandler;
+            markAsDirty();
+        }
+    }
+
+    /**
+     * Returns the mode of which dragging is visualized.
+     * 
+     * @return
+     */
+    public LayoutDragMode getDragMode() {
+        return getState().ddState.dragMode;
+    }
+
+    /**
+     * Enables dragging components from the layout.
+     * 
+     * @param mode
+     *            The mode of which how the dragging should be visualized.
+     */
+    public void setDragMode(LayoutDragMode mode) {
+        getState().ddState.dragMode = mode;
+    }
+
+    /**
+     * Sets the ratio which determines how a cell is divided into drop zones.
+     * The ratio is measured from the left and right borders. For example,
+     * setting the ratio to 0.3 will divide the drop zone in three equal parts
+     * (left,middle,right). Setting the ratio to 0.5 will disable dropping in
+     * the middle and setting it to 0 will disable dropping at the sides.
+     * 
+     * @param ratio
+     *            A ratio between 0 and 0.5. Default is 0.2
+     */
+    public void setComponentHorizontalDropRatio(float ratio) {
+        if (getState().cellLeftRightDropRatio != ratio) {
+            if (ratio >= 0 && ratio <= 0.5) {
+                getState().cellLeftRightDropRatio = ratio;
+            } else {
+                throw new IllegalArgumentException(
+                        "Ratio must be between 0 and 0.5");
+            }
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void setShim(boolean shim) {
+        getState().ddState.iframeShims = shim;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean isShimmed() {
+        return getState().ddState.iframeShims;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public DragFilter getDragFilter() {
+        return dragFilter;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void setDragFilter(DragFilter dragFilter) {
+        this.dragFilter = dragFilter;
+    }
+
+    @Override
+    public DDHorizontalLayoutState getState() {
+        return (DDHorizontalLayoutState) super.getState();
+    }
+
+    @Override
+    public void beforeClientResponse(boolean initial) {
+        super.beforeClientResponse(initial);
+        DDUtil.onBeforeClientResponse(this, getState());
+    }
+
+    @Override
+    public void changeVariables(Object source, Map<String, Object> variables) {
+        // TODO Auto-generated method stub
+    }
+
+    @Override
+    public void setDragImageProvider(DragImageProvider provider) {
+        this.dragImageProvider = provider;
+        markAsDirty();
+    }
+
+    @Override
+    public DragImageProvider getDragImageProvider() {
+        return this.dragImageProvider;
+    }
+}

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/v7/DDVerticalLayout.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/v7/DDVerticalLayout.java
@@ -1,0 +1,293 @@
+/*
+ * Copyright 2015 John Ahlroos
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package fi.jasoft.dragdroplayouts.v7;
+
+import java.util.Map;
+
+import com.vaadin.event.Transferable;
+import com.vaadin.event.dd.DropHandler;
+import com.vaadin.event.dd.DropTarget;
+import com.vaadin.event.dd.TargetDetails;
+import com.vaadin.event.dd.TargetDetailsImpl;
+import com.vaadin.server.PaintException;
+import com.vaadin.server.PaintTarget;
+import com.vaadin.shared.MouseEventDetails;
+import com.vaadin.shared.ui.dd.VerticalDropLocation;
+import com.vaadin.ui.Component;
+import com.vaadin.ui.LegacyComponent;
+import com.vaadin.v7.ui.VerticalLayout;
+
+import fi.jasoft.dragdroplayouts.DDUtil;
+import fi.jasoft.dragdroplayouts.client.ui.Constants;
+import fi.jasoft.dragdroplayouts.client.ui.LayoutDragMode;
+import fi.jasoft.dragdroplayouts.v7.client.ui.verticallayout
+        .DDVerticalLayoutState;
+import fi.jasoft.dragdroplayouts.events.LayoutBoundTransferable;
+import fi.jasoft.dragdroplayouts.interfaces.DragFilter;
+import fi.jasoft.dragdroplayouts.interfaces.DragFilterSupport;
+import fi.jasoft.dragdroplayouts.interfaces.DragImageProvider;
+import fi.jasoft.dragdroplayouts.interfaces.DragImageReferenceSupport;
+import fi.jasoft.dragdroplayouts.interfaces.LayoutDragSource;
+import fi.jasoft.dragdroplayouts.interfaces.ShimSupport;
+
+/**
+ * Vertical layout with drag and drop support
+ * 
+ * @author John Ahlroos / www.jasoft.fi
+ * @since 0.4.0
+ */
+@SuppressWarnings("serial")
+public class DDVerticalLayout extends VerticalLayout
+        implements LayoutDragSource, DropTarget, ShimSupport, LegacyComponent,
+        DragFilterSupport, DragImageReferenceSupport {
+    /**
+     * The drop handler which handles dropped components in the layout.
+     */
+    private DropHandler dropHandler;
+
+    // A filter for dragging components.
+    private DragFilter dragFilter = DragFilter.ALL;
+
+    private DragImageProvider dragImageProvider;
+
+    /**
+     * Contains the component over which the drop was made and the index on
+     * which the drop was made.
+     */
+    public class VerticalLayoutTargetDetails extends TargetDetailsImpl {
+
+        private Component over;
+
+        private int index = -1;
+
+        protected VerticalLayoutTargetDetails(Map<String, Object> rawDropData) {
+            super(rawDropData, DDVerticalLayout.this);
+
+            // Get over which component (if any) the drop was made and the
+            // index of it
+            if (getData(Constants.DROP_DETAIL_TO) != null) {
+                index = Integer
+                        .valueOf(getData(Constants.DROP_DETAIL_TO).toString());
+                if (index >= 0 && index < components.size()) {
+                    over = components.get(index);
+                }
+            }
+
+            // Was the drop over no specific cell
+            if (over == null) {
+                over = DDVerticalLayout.this;
+            }
+        }
+
+        /**
+         * The component over which the drop was made.
+         * 
+         * @return Null if the drop was not over a component, else the component
+         */
+        public Component getOverComponent() {
+            return over;
+        }
+
+        /**
+         * The index over which the drop was made. If the drop was not made over
+         * any component then it returns -1.
+         * 
+         * @return The index of the component or -1 if over no component.
+         */
+        public int getOverIndex() {
+            return index;
+        }
+
+        /**
+         * Some details about the mouse event
+         * 
+         * @return details about the actual event that caused the event details.
+         *         Practically mouse move or mouse up.
+         */
+        public MouseEventDetails getMouseEvent() {
+            return MouseEventDetails.deSerialize(
+                    (String) getData(Constants.DROP_DETAIL_MOUSE_EVENT));
+        }
+
+        /**
+         * Get the horizontal position of the dropped component within the
+         * underlying cell.
+         * 
+         * @return The drop location
+         */
+        public VerticalDropLocation getDropLocation() {
+            return VerticalDropLocation.valueOf((String) getData(
+                    Constants.DROP_DETAIL_VERTICAL_DROP_LOCATION));
+        }
+    }
+
+    /**
+     * Creates a new vertical layout
+     */
+    public DDVerticalLayout() {
+        super();
+    }
+
+    /**
+     * Creates a new vertical layout with children
+     * 
+     * @param components
+     *            the child components to add to the layout
+     */
+    public DDVerticalLayout(Component... components) {
+        super(components);
+    }
+
+    /**
+     * {@inheritDoc}
+     * 
+     */
+    public void paintContent(PaintTarget target) throws PaintException {
+        if (dropHandler != null && isEnabled()) {
+            dropHandler.getAcceptCriterion().paint(target);
+        }
+    }
+
+    public TargetDetails translateDropTargetDetails(
+            Map<String, Object> clientVariables) {
+        return new VerticalLayoutTargetDetails(clientVariables);
+    }
+
+    /**
+     * Get the transferable created by a drag event.
+     */
+    public Transferable getTransferable(Map<String, Object> rawVariables) {
+        return new LayoutBoundTransferable(this, rawVariables);
+    }
+
+    /**
+     * Returns the drop handler which handles drop events from dropping
+     * components on the layout. Returns Null if dropping is disabled.
+     */
+    public DropHandler getDropHandler() {
+        return dropHandler;
+    }
+
+    /**
+     * Sets the current handler which handles dropped components on the layout.
+     * By setting a drop handler dropping components on the layout is enabled.
+     * By setting the dropHandler to null dropping is disabled.
+     * 
+     * @param dropHandler
+     *            The drop handler to handle drop events or null to disable
+     *            dropping
+     */
+    public void setDropHandler(DropHandler dropHandler) {
+        DDUtil.verifyHandlerType(this, dropHandler);
+        if (this.dropHandler != dropHandler) {
+            this.dropHandler = dropHandler;
+            markAsDirty();
+        }
+    }
+
+    /**
+     * Returns the mode of which dragging is visualized.
+     * 
+     * @return
+     */
+    public LayoutDragMode getDragMode() {
+        return getState().ddState.dragMode;
+    }
+
+    /**
+     * Enables dragging components from the layout.
+     * 
+     * @param mode
+     *            The mode of which how the dragging should be visualized.
+     */
+    public void setDragMode(LayoutDragMode mode) {
+        getState().ddState.dragMode = mode;
+    }
+
+    /**
+     * Sets the ratio which determines how a cell is divided into drop zones.
+     * The ratio is measured from the top and bottom borders. For example,
+     * setting the ratio to 0.3 will divide the drop zone in three equal parts
+     * (left,middle,right). Setting the ratio to 0.5 will disable dropping in
+     * the middle and setting it to 0 will disable dropping at the sides.
+     * 
+     * @param ratio
+     *            A ratio between 0 and 0.5. Default is 0.2
+     */
+    public void setComponentVerticalDropRatio(float ratio) {
+        if (getState().cellTopBottomDropRatio != ratio) {
+            if (ratio >= 0 && ratio <= 0.5) {
+                getState().cellTopBottomDropRatio = ratio;
+            } else {
+                throw new IllegalArgumentException(
+                        "Ratio must be between 0 and 0.5");
+            }
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void setShim(boolean shim) {
+        getState().ddState.iframeShims = shim;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean isShimmed() {
+        return getState().ddState.iframeShims;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public DragFilter getDragFilter() {
+        return dragFilter;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void setDragFilter(DragFilter dragFilter) {
+        this.dragFilter = dragFilter;
+    }
+
+    @Override
+    public DDVerticalLayoutState getState() {
+        return (DDVerticalLayoutState) super.getState();
+    }
+
+    @Override
+    public void beforeClientResponse(boolean initial) {
+        super.beforeClientResponse(initial);
+        DDUtil.onBeforeClientResponse(this, getState());
+    }
+
+    @Override
+    public void changeVariables(Object source, Map<String, Object> variables) {
+        // TODO Auto-generated method stub
+    }
+
+    @Override
+    public void setDragImageProvider(DragImageProvider provider) {
+        this.dragImageProvider = provider;
+        markAsDirty();
+    }
+
+    @Override
+    public DragImageProvider getDragImageProvider() {
+        return this.dragImageProvider;
+    }
+}

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/v7/client/ui/horizontallayout/DDHorizontalLayoutConnector.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/v7/client/ui/horizontallayout/DDHorizontalLayoutConnector.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2015 John Ahlroos
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package fi.jasoft.dragdroplayouts.v7.client.ui.horizontallayout;
+
+import com.vaadin.client.ApplicationConnection;
+import com.vaadin.client.Paintable;
+import com.vaadin.client.UIDL;
+import com.vaadin.client.ui.orderedlayout.HorizontalLayoutConnector;
+import com.vaadin.shared.ui.Connect;
+
+import fi.jasoft.dragdroplayouts.v7.DDHorizontalLayout;
+import fi.jasoft.dragdroplayouts.client.VDragFilter;
+import fi.jasoft.dragdroplayouts.client.ui.VDragDropUtil;
+import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasDragFilter;
+import fi.jasoft.dragdroplayouts.client.ui.util.HTML5Support;
+
+@Connect(DDHorizontalLayout.class)
+public class DDHorizontalLayoutConnector extends HorizontalLayoutConnector
+        implements Paintable, VHasDragFilter {
+
+    private HTML5Support html5Support;
+
+    @Override
+    public VDDHorizontalLayout getWidget() {
+        return (VDDHorizontalLayout) super.getWidget();
+    }
+
+    @Override
+    public DDHorizontalLayoutState getState() {
+        return (DDHorizontalLayoutState) super.getState();
+    }
+
+    @Override
+    public void init() {
+        super.init();
+        VDragDropUtil.listenToStateChangeEvents(this, getWidget());
+    }
+
+    public void updateFromUIDL(UIDL uidl, ApplicationConnection client) {
+        VDragDropUtil.updateDropHandlerFromUIDL(uidl, this, new VDDHorizontalLayoutDropHandler(this));
+        if (html5Support != null) {
+            html5Support.disable();
+            html5Support = null;
+        }
+        VDDHorizontalLayoutDropHandler dropHandler = getWidget().getDropHandler();
+        if (dropHandler != null) {
+            html5Support = HTML5Support.enable(this, dropHandler);
+        }
+    }
+
+    @Override
+    public void onUnregister() {
+        if (html5Support != null) {
+            html5Support.disable();
+            html5Support = null;
+        }
+        super.onUnregister();
+    }
+
+    @Override
+    public VDragFilter getDragFilter() {
+        return getWidget().getDragFilter();
+    }
+
+    @Override
+    public void setDragFilter(VDragFilter filter) {
+        getWidget().setDragFilter(filter);
+    }
+}

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/v7/client/ui/horizontallayout/DDHorizontalLayoutState.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/v7/client/ui/horizontallayout/DDHorizontalLayoutState.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2015 John Ahlroos
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package fi.jasoft.dragdroplayouts.v7.client.ui.horizontallayout;
+
+import com.vaadin.shared.annotations.DelegateToWidget;
+import com.vaadin.shared.ui.orderedlayout.HorizontalLayoutState;
+
+import fi.jasoft.dragdroplayouts.client.ui.interfaces.DDLayoutState;
+import fi.jasoft.dragdroplayouts.client.ui.interfaces.DragAndDropAwareState;
+
+public class DDHorizontalLayoutState extends HorizontalLayoutState
+        implements DragAndDropAwareState {
+
+    public static final float DEFAULT_HORIZONTAL_DROP_RATIO = 0.2f;
+
+    @DelegateToWidget
+    public float cellLeftRightDropRatio = DEFAULT_HORIZONTAL_DROP_RATIO;
+
+    public DDLayoutState ddState = new DDLayoutState();
+
+    @Override
+    public DDLayoutState getDragAndDropState() {
+        return ddState;
+    }
+}

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/v7/client/ui/horizontallayout/VDDHorizontalLayout.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/v7/client/ui/horizontallayout/VDDHorizontalLayout.java
@@ -1,0 +1,336 @@
+/*
+ * Copyright 2015 John Ahlroos
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package fi.jasoft.dragdroplayouts.v7.client.ui.horizontallayout;
+
+import com.google.gwt.user.client.ui.UIObject;
+import com.google.gwt.user.client.ui.Widget;
+import com.google.gwt.user.client.ui.WidgetCollection;
+import com.vaadin.client.ComponentConnector;
+import com.vaadin.client.MouseEventDetailsBuilder;
+import com.vaadin.client.Util;
+import com.vaadin.client.ui.VHorizontalLayout;
+import com.vaadin.client.ui.dd.VDragEvent;
+import com.vaadin.client.ui.orderedlayout.Slot;
+import com.vaadin.shared.MouseEventDetails;
+import com.vaadin.shared.ui.dd.HorizontalDropLocation;
+
+import fi.jasoft.dragdroplayouts.v7.DDHorizontalLayout;
+import fi.jasoft.dragdroplayouts.client.VDragFilter;
+import fi.jasoft.dragdroplayouts.client.ui.Constants;
+import fi.jasoft.dragdroplayouts.client.ui.LayoutDragMode;
+import fi.jasoft.dragdroplayouts.client.ui.VDragDropUtil;
+import fi.jasoft.dragdroplayouts.client.ui.VLayoutDragDropMouseHandler;
+import fi.jasoft.dragdroplayouts.client.ui.VLayoutDragDropMouseHandler.DragStartListener;
+import fi.jasoft.dragdroplayouts.client.ui.interfaces.VDDHasDropHandler;
+import fi.jasoft.dragdroplayouts.client.ui.interfaces.VDragImageProvider;
+import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasDragFilter;
+import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasDragImageReferenceSupport;
+import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasDragMode;
+import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasIframeShims;
+import fi.jasoft.dragdroplayouts.client.ui.util.IframeCoverUtility;
+
+/**
+ * Client side implementation for {@link DDHorizontalLayout}
+ * 
+ * @author John Ahlroos / www.jasoft.fi
+ * @since 0.4.0
+ */
+public class VDDHorizontalLayout extends VHorizontalLayout
+        implements VHasDragMode,
+        VDDHasDropHandler<VDDHorizontalLayoutDropHandler>, DragStartListener,
+        VHasDragFilter, VHasDragImageReferenceSupport, VHasIframeShims {
+
+    public static final String OVER = "v-ddorderedlayout-over";
+    public static final String OVER_SPACED = OVER + "-spaced";
+
+    private Widget currentlyEmphasised;
+
+    private VDDHorizontalLayoutDropHandler dropHandler;
+
+    private VDragFilter dragFilter;
+
+    private final IframeCoverUtility iframeCoverUtility = new IframeCoverUtility();
+
+    private final VLayoutDragDropMouseHandler ddMouseHandler = new VLayoutDragDropMouseHandler(
+            this, LayoutDragMode.NONE);
+
+    // Value delegated from state
+    private double cellLeftRightDropRatio = DDHorizontalLayoutState.DEFAULT_HORIZONTAL_DROP_RATIO;
+
+    private LayoutDragMode mode = LayoutDragMode.NONE;
+
+    private boolean iframeCovers = false;
+
+    public VDDHorizontalLayout() {
+        super();
+    }
+
+    @Override
+    protected void onLoad() {
+        super.onLoad();
+        ddMouseHandler.addDragStartListener(this);
+        setDragMode(mode);
+        iframeShimsEnabled(iframeCovers);
+    }
+
+    @Override
+    protected void onUnload() {
+        super.onUnload();
+        ddMouseHandler.removeDragStartListener(this);
+        ddMouseHandler.updateDragMode(LayoutDragMode.NONE);
+        iframeCoverUtility.setIframeCoversEnabled(false, getElement(),
+                LayoutDragMode.NONE);
+    }
+
+    /**
+     * Removes any applies drag and drop style applied by emphasis()
+     */
+    protected void deEmphasis() {
+        if (currentlyEmphasised != null) {
+            // Universal over style
+            UIObject.setStyleName(currentlyEmphasised.getElement(), OVER,
+                    false);
+            UIObject.setStyleName(currentlyEmphasised.getElement(), OVER_SPACED,
+                    false);
+
+            // Horizontal styles
+            UIObject.setStyleName(currentlyEmphasised.getElement(), OVER + "-"
+                    + HorizontalDropLocation.LEFT.toString().toLowerCase(),
+                    false);
+            UIObject.setStyleName(currentlyEmphasised.getElement(), OVER + "-"
+                    + HorizontalDropLocation.CENTER.toString().toLowerCase(),
+                    false);
+            UIObject.setStyleName(currentlyEmphasised.getElement(), OVER + "-"
+                    + HorizontalDropLocation.RIGHT.toString().toLowerCase(),
+                    false);
+
+            currentlyEmphasised = null;
+        }
+    }
+
+    /**
+     * Returns the horizontal location within the cell when hoovering over the
+     * cell. By default the cell is devided into three parts: left,center,right
+     * with the ratios 10%,80%,10%;
+     * 
+     * @param container
+     *            The widget container
+     * @param event
+     *            The drag event
+     * @return The horizontal drop location
+     */
+    protected HorizontalDropLocation getHorizontalDropLocation(Widget container,
+            VDragEvent event) {
+        return VDragDropUtil.getHorizontalDropLocation(container.getElement(),
+                Util.getTouchOrMouseClientX(event.getCurrentGwtEvent()),
+                cellLeftRightDropRatio);
+    }
+
+    /**
+     * A hook for extended components to post process the the drop before it is
+     * sent to the server. Useful if you don't want to override the whole drop
+     * handler.
+     */
+    protected boolean postDropHook(VDragEvent drag) {
+        // Extended classes can add content here...
+        return true;
+    }
+
+    /**
+     * A hook for extended components to post process the the enter event.
+     * Useful if you don't want to override the whole drophandler.
+     */
+    protected void postEnterHook(VDragEvent drag) {
+        // Extended classes can add content here...
+    }
+
+    /**
+     * A hook for extended components to post process the the leave event.
+     * Useful if you don't want to override the whole drophandler.
+     */
+    protected void postLeaveHook(VDragEvent drag) {
+        // Extended classes can add content here...
+    }
+
+    /**
+     * A hook for extended components to post process the the over event. Useful
+     * if you don't want to override the whole drophandler.
+     */
+    protected void postOverHook(VDragEvent drag) {
+        // Extended classes can add content here...
+    }
+
+    /**
+     * Can be used to listen to drag start events, must return true for the drag
+     * to commence. Return false to interrupt the drag:
+     */
+    @Override
+    public boolean dragStart(Widget widget, LayoutDragMode mode) {
+        ComponentConnector layout = Util.findConnectorFor(this);
+        return VDragDropUtil.isDraggingEnabled(layout, widget);
+    }
+
+    /**
+     * Updates the drop details while dragging. This is needed to ensure client
+     * side criterias can validate the drop location.
+     * 
+     * @param widget
+     *            The container which we are hovering over
+     * @param event
+     *            The drag event
+     */
+    protected void updateDragDetails(Widget widget, VDragEvent event) {
+        if (widget == null) {
+            return;
+        }
+
+        /*
+         * The horizontal position within the cell{
+         */
+        event.getDropDetails().put(
+                Constants.DROP_DETAIL_HORIZONTAL_DROP_LOCATION,
+                getHorizontalDropLocation(widget, event));
+
+        /*
+         * The index over which the drag is. Can be used by a client side
+         * criteria to verify that a drag is over a certain index.
+         */
+        int index = -1;
+        if (widget instanceof Slot) {
+            WidgetCollection captionsAndSlots = getChildren();
+            index = VDragDropUtil.findSlotIndex(captionsAndSlots,
+                    (Slot) widget);
+        }
+
+        event.getDropDetails().put(Constants.DROP_DETAIL_TO, index);
+
+        // Add mouse event details
+        MouseEventDetails details = MouseEventDetailsBuilder
+                .buildMouseEventDetails(event.getCurrentGwtEvent(),
+                        getElement());
+        event.getDropDetails().put(Constants.DROP_DETAIL_MOUSE_EVENT,
+                details.serialize());
+    }
+
+    /**
+     * Empasises the drop location of the component when hovering over a
+     * ĆhildComponentContainer. Passing null as the container removes any
+     * previous emphasis.
+     * 
+     * @param container
+     *            The container which we are hovering over
+     * @param event
+     *            The drag event
+     */
+    protected void emphasis(Widget container, VDragEvent event) {
+
+        // Remove emphasis from previous hovers
+        deEmphasis();
+
+        // validate container
+        if (container == null
+                || !getElement().isOrHasChild(container.getElement())) {
+            return;
+        }
+
+        currentlyEmphasised = container;
+
+        HorizontalDropLocation location = null;
+
+        // Add drop location specific style
+        if (currentlyEmphasised != this) {
+            location = getHorizontalDropLocation(container, event);
+
+        } else {
+            location = HorizontalDropLocation.CENTER;
+        }
+
+        UIObject.setStyleName(currentlyEmphasised.getElement(), OVER, true);
+        UIObject.setStyleName(currentlyEmphasised.getElement(),
+                OVER + "-" + location.toString().toLowerCase(), true);
+    }
+
+    /**
+     * Returns the current drag mode which determines how the drag is visualized
+     */
+    public LayoutDragMode getDragMode() {
+        return ddMouseHandler.getDragMode();
+    }
+
+    /**
+     * Creates a drop handler if one does not already exist and updates it from
+     * the details received from the server.
+     * 
+     * @param dropHandler
+     *            The drop handler
+     */
+    public void setDropHandler(VDDHorizontalLayoutDropHandler dropHandler) {
+        this.dropHandler = dropHandler;
+    }
+
+    /**
+     * Get the drop handler attached to the Layout
+     */
+    public VDDHorizontalLayoutDropHandler getDropHandler() {
+        return dropHandler;
+    }
+
+    public VDragFilter getDragFilter() {
+        return dragFilter;
+    }
+
+    IframeCoverUtility getIframeCoverUtility() {
+        return iframeCoverUtility;
+    }
+
+    public double getCellLeftRightDropRatio() {
+        return cellLeftRightDropRatio;
+    }
+
+    public void setCellLeftRightDropRatio(float cellLeftRightDropRatio) {
+        this.cellLeftRightDropRatio = cellLeftRightDropRatio;
+    }
+
+    @Override
+    public void setDragFilter(VDragFilter filter) {
+        this.dragFilter = filter;
+    }
+
+    @Override
+    public void iframeShimsEnabled(boolean enabled) {
+        iframeCovers = enabled;
+        iframeCoverUtility.setIframeCoversEnabled(enabled, getElement(), mode);
+    }
+
+    @Override
+    public boolean isIframeShimsEnabled() {
+        return iframeCovers;
+    }
+
+    @Override
+    public void setDragMode(LayoutDragMode mode) {
+        this.mode = mode;
+        ddMouseHandler.updateDragMode(mode);
+        iframeShimsEnabled(iframeCovers);
+    }
+
+    @Override
+    public void setDragImageProvider(VDragImageProvider provider) {
+        ddMouseHandler.setDragImageProvider(provider);
+    }
+
+    protected final VLayoutDragDropMouseHandler getMouseHandler() {
+        return ddMouseHandler;
+    }
+}

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/v7/client/ui/horizontallayout/VDDHorizontalLayoutDropHandler.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/v7/client/ui/horizontallayout/VDDHorizontalLayoutDropHandler.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2015 John Ahlroos
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package fi.jasoft.dragdroplayouts.v7.client.ui.horizontallayout;
+
+import com.google.gwt.dom.client.Element;
+import com.google.gwt.dom.client.NativeEvent;
+import com.google.gwt.user.client.ui.Widget;
+import com.vaadin.client.ComponentConnector;
+import com.vaadin.client.WidgetUtil;
+import com.vaadin.client.ui.dd.VAcceptCallback;
+import com.vaadin.client.ui.dd.VDragEvent;
+import com.vaadin.client.ui.orderedlayout.Slot;
+import com.vaadin.client.ui.orderedlayout.VAbstractOrderedLayout;
+
+import fi.jasoft.dragdroplayouts.client.ui.VDDAbstractOrderedLayoutDropHandler;
+import fi.jasoft.dragdroplayouts.client.ui.VDragDropUtil;
+
+public class VDDHorizontalLayoutDropHandler
+        extends VDDAbstractOrderedLayoutDropHandler<VDDHorizontalLayout> {
+
+    public VDDHorizontalLayoutDropHandler(ComponentConnector connector) {
+        super(connector);
+    }
+
+    @Override
+    protected void dragAccepted(VDragEvent drag) {
+        dragOver(drag);
+    }
+
+    @Override
+    public boolean drop(VDragEvent drag) {
+
+        // Un-emphasis any selections
+        getLayout().emphasis(null, null);
+
+        // Update the details
+        Widget slot = getSlot(drag.getElementOver(), drag.getCurrentGwtEvent());
+        getLayout().updateDragDetails(slot, drag);
+
+        return getLayout().postDropHook(drag) && super.drop(drag);
+    }
+
+    @Override
+    protected Slot getSlot(Element e, NativeEvent event) {
+        Slot slot = null;
+        if (getLayout().getElement() == e) {
+            // Most likely between components, use the closes one in that case
+            slot = findSlotHorizontally(12, event);
+        } else {
+            slot = WidgetUtil.findWidget(e, Slot.class);
+            if (slot == null) {
+                return null;
+            }
+            VAbstractOrderedLayout layout = VDragDropUtil.getSlotLayout(slot);
+            while (layout != getLayout() && getLayout().getElement()
+                    .isOrHasChild(e.getParentElement())) {
+                e = e.getParentElement();
+                slot = WidgetUtil.findWidget(e, Slot.class);
+                if (slot == null) {
+                    return null;
+                }
+                layout = VDragDropUtil.getSlotLayout(slot);
+            }
+        }
+
+        return slot;
+    }
+
+    @Override
+    public void dragOver(VDragEvent drag) {
+
+        // Remove any emphasis
+        getLayout().emphasis(null, null);
+
+        Slot slot = getSlot(drag.getElementOver(), drag.getCurrentGwtEvent());
+
+        if (slot != null) {
+            getLayout().updateDragDetails(slot, drag);
+        } else {
+            getLayout().updateDragDetails(getLayout(), drag);
+        }
+
+        getLayout().postOverHook(drag);
+
+        // Validate the drop
+        validate(new VAcceptCallback() {
+            public void accepted(VDragEvent event) {
+                Slot slot = getSlot(event.getElementOver(),
+                        event.getCurrentGwtEvent());
+                if (slot != null) {
+                    getLayout().emphasis(slot, event);
+                } else {
+                    getLayout().emphasis(getLayout(), event);
+                }
+            }
+        }, drag);
+    }
+
+    @Override
+    public void dragEnter(VDragEvent drag) {
+        super.dragEnter(drag);
+        Slot slot = getSlot(drag.getElementOver(), drag.getCurrentGwtEvent());
+        if (slot != null) {
+            getLayout().updateDragDetails(slot, drag);
+        } else {
+            getLayout().updateDragDetails(getLayout(), drag);
+        }
+
+        getLayout().postEnterHook(drag);
+    }
+
+    @Override
+    public void dragLeave(VDragEvent drag) {
+        getLayout().deEmphasis();
+        getLayout().postLeaveHook(drag);
+    }
+
+}

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/v7/client/ui/verticallayout/DDVerticalLayoutConnector.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/v7/client/ui/verticallayout/DDVerticalLayoutConnector.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2015 John Ahlroos
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package fi.jasoft.dragdroplayouts.v7.client.ui.verticallayout;
+
+import com.vaadin.client.ApplicationConnection;
+import com.vaadin.client.Paintable;
+import com.vaadin.client.UIDL;
+import com.vaadin.client.ui.orderedlayout.VerticalLayoutConnector;
+import com.vaadin.shared.ui.Connect;
+
+import fi.jasoft.dragdroplayouts.v7.DDVerticalLayout;
+import fi.jasoft.dragdroplayouts.client.VDragFilter;
+import fi.jasoft.dragdroplayouts.client.ui.VDragDropUtil;
+import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasDragFilter;
+import fi.jasoft.dragdroplayouts.client.ui.util.HTML5Support;
+
+@Connect(DDVerticalLayout.class)
+public class DDVerticalLayoutConnector extends VerticalLayoutConnector
+        implements Paintable, VHasDragFilter {
+
+    private HTML5Support html5Support;
+
+    @Override
+    public VDDVerticalLayout getWidget() {
+        return (VDDVerticalLayout) super.getWidget();
+    }
+
+    @Override
+    public DDVerticalLayoutState getState() {
+        return (DDVerticalLayoutState) super.getState();
+    }
+
+    @Override
+    public void init() {
+        super.init();
+        VDragDropUtil.listenToStateChangeEvents(this, getWidget());
+    }
+
+    public void updateFromUIDL(UIDL uidl, ApplicationConnection client) {
+        VDragDropUtil.updateDropHandlerFromUIDL(uidl, this, new VDDVerticalLayoutDropHandler(this));
+        if (html5Support != null) {
+            html5Support.disable();
+            html5Support = null;
+        }
+        VDDVerticalLayoutDropHandler dropHandler = getWidget().getDropHandler();
+        if (dropHandler != null) {
+            html5Support = HTML5Support.enable(this, dropHandler);
+        }
+    }
+
+    @Override
+    public void onUnregister() {
+        if (html5Support != null) {
+            html5Support.disable();
+            html5Support = null;
+        }
+        super.onUnregister();
+    }
+
+    @Override
+    public VDragFilter getDragFilter() {
+        return getWidget().getDragFilter();
+    }
+
+    @Override
+    public void setDragFilter(VDragFilter filter) {
+        getWidget().setDragFilter(filter);
+    }
+}

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/v7/client/ui/verticallayout/DDVerticalLayoutState.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/v7/client/ui/verticallayout/DDVerticalLayoutState.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2015 John Ahlroos
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package fi.jasoft.dragdroplayouts.v7.client.ui.verticallayout;
+
+import com.vaadin.shared.annotations.DelegateToWidget;
+import com.vaadin.shared.ui.orderedlayout.VerticalLayoutState;
+
+import fi.jasoft.dragdroplayouts.client.ui.interfaces.DDLayoutState;
+import fi.jasoft.dragdroplayouts.client.ui.interfaces.DragAndDropAwareState;
+
+public class DDVerticalLayoutState extends VerticalLayoutState
+        implements DragAndDropAwareState {
+
+    public static final float DEFAULT_VERTICAL_DROP_RATIO = 0.2f;
+
+    @DelegateToWidget
+    public float cellTopBottomDropRatio = DEFAULT_VERTICAL_DROP_RATIO;
+
+    public DDLayoutState ddState = new DDLayoutState();
+
+    @Override
+    public DDLayoutState getDragAndDropState() {
+        return ddState;
+    }
+}

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/v7/client/ui/verticallayout/VDDVerticalLayout.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/v7/client/ui/verticallayout/VDDVerticalLayout.java
@@ -1,0 +1,335 @@
+/*
+ * Copyright 2015 John Ahlroos
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package fi.jasoft.dragdroplayouts.v7.client.ui.verticallayout;
+
+import com.google.gwt.user.client.ui.UIObject;
+import com.google.gwt.user.client.ui.Widget;
+import com.google.gwt.user.client.ui.WidgetCollection;
+import com.vaadin.client.ComponentConnector;
+import com.vaadin.client.MouseEventDetailsBuilder;
+import com.vaadin.client.Util;
+import com.vaadin.client.ui.VVerticalLayout;
+import com.vaadin.client.ui.dd.VDragEvent;
+import com.vaadin.client.ui.orderedlayout.Slot;
+import com.vaadin.shared.MouseEventDetails;
+import com.vaadin.shared.ui.dd.VerticalDropLocation;
+
+import fi.jasoft.dragdroplayouts.v7.DDVerticalLayout;
+import fi.jasoft.dragdroplayouts.client.VDragFilter;
+import fi.jasoft.dragdroplayouts.client.ui.Constants;
+import fi.jasoft.dragdroplayouts.client.ui.LayoutDragMode;
+import fi.jasoft.dragdroplayouts.client.ui.VDragDropUtil;
+import fi.jasoft.dragdroplayouts.client.ui.VLayoutDragDropMouseHandler;
+import fi.jasoft.dragdroplayouts.client.ui.VLayoutDragDropMouseHandler.DragStartListener;
+import fi.jasoft.dragdroplayouts.client.ui.interfaces.VDDHasDropHandler;
+import fi.jasoft.dragdroplayouts.client.ui.interfaces.VDragImageProvider;
+import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasDragFilter;
+import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasDragImageReferenceSupport;
+import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasDragMode;
+import fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasIframeShims;
+import fi.jasoft.dragdroplayouts.client.ui.util.IframeCoverUtility;
+
+/**
+ * Client side implementation for {@link DDVerticalLayout}
+ * 
+ * @author John Ahlroos / www.jasoft.fi
+ * @since 0.4.0
+ */
+public class VDDVerticalLayout extends VVerticalLayout implements VHasDragMode,
+        VDDHasDropHandler<VDDVerticalLayoutDropHandler>, DragStartListener,
+        VHasDragFilter, VHasIframeShims, VHasDragImageReferenceSupport {
+
+    private Widget currentlyEmphasised;
+
+    public static final String OVER = "v-ddorderedlayout-over";
+
+    public static final String OVER_SPACED = OVER + "-spaced";
+
+    private VDDVerticalLayoutDropHandler dropHandler;
+
+    private VDragFilter dragFilter;
+
+    private final IframeCoverUtility iframeCoverUtility = new IframeCoverUtility();
+
+    private final VLayoutDragDropMouseHandler ddMouseHandler = new VLayoutDragDropMouseHandler(
+            this, LayoutDragMode.NONE);
+
+    // Value delegated from the state
+    private float cellTopBottomDropRatio = DDVerticalLayoutState.DEFAULT_VERTICAL_DROP_RATIO;
+
+    private LayoutDragMode mode = LayoutDragMode.NONE;
+
+    private boolean iframeCovers = false;
+
+    public VDDVerticalLayout() {
+        super();
+    }
+
+    @Override
+    protected void onLoad() {
+        super.onLoad();
+        ddMouseHandler.addDragStartListener(this);
+        setDragMode(mode);
+        iframeShimsEnabled(iframeCovers);
+    }
+
+    @Override
+    protected void onUnload() {
+        super.onUnload();
+        ddMouseHandler.removeDragStartListener(this);
+        ddMouseHandler.updateDragMode(LayoutDragMode.NONE);
+        iframeCoverUtility.setIframeCoversEnabled(false, getElement(),
+                LayoutDragMode.NONE);
+    }
+
+    /**
+     * Removes any applies drag and drop style applied by emphasis()
+     */
+    protected void deEmphasis() {
+        if (currentlyEmphasised != null) {
+            // Universal over style
+            UIObject.setStyleName(currentlyEmphasised.getElement(), OVER,
+                    false);
+            UIObject.setStyleName(currentlyEmphasised.getElement(), OVER_SPACED,
+                    false);
+
+            // Vertical styles
+            UIObject.setStyleName(currentlyEmphasised.getElement(),
+                    OVER + "-"
+                            + VerticalDropLocation.TOP.toString().toLowerCase(),
+                    false);
+            UIObject.setStyleName(currentlyEmphasised.getElement(), OVER + "-"
+                    + VerticalDropLocation.MIDDLE.toString().toLowerCase(),
+                    false);
+            UIObject.setStyleName(currentlyEmphasised.getElement(), OVER + "-"
+                    + VerticalDropLocation.BOTTOM.toString().toLowerCase(),
+                    false);
+
+            currentlyEmphasised = null;
+        }
+    }
+
+    /**
+     * Returns the horizontal location within the cell when hovering over the
+     * cell. By default the cell is divided into three parts: left,center,right
+     * with the ratios 10%,80%,10%;
+     * 
+     * @param container
+     *            The widget container
+     * @param event
+     *            The drag event
+     * @return The horizontal drop location
+     */
+    protected VerticalDropLocation getVerticalDropLocation(Widget container,
+            VDragEvent event) {
+        return VDragDropUtil.getVerticalDropLocation(container.getElement(),
+                Util.getTouchOrMouseClientY(event.getCurrentGwtEvent()),
+                cellTopBottomDropRatio);
+    }
+
+    /**
+     * Updates the drop details while dragging. This is needed to ensure client
+     * side criterias can validate the drop location.
+     * 
+     * @param widget
+     *            The container which we are hovering over
+     * @param event
+     *            The drag event
+     */
+    protected void updateDragDetails(Widget widget, VDragEvent event) {
+        if (widget == null) {
+            return;
+        }
+
+        /*
+         * The horizontal position within the cell{
+         */
+        event.getDropDetails().put(Constants.DROP_DETAIL_VERTICAL_DROP_LOCATION,
+                getVerticalDropLocation(widget, event));
+
+        /*
+         * The index over which the drag is. Can be used by a client side
+         * criteria to verify that a drag is over a certain index.
+         */
+        int index = -1;
+        if (widget instanceof Slot) {
+            WidgetCollection captionsAndSlots = getChildren();
+            index = VDragDropUtil.findSlotIndex(captionsAndSlots,
+                    (Slot) widget);
+        }
+
+        event.getDropDetails().put(Constants.DROP_DETAIL_TO, index);
+
+        // Add mouse event details
+        MouseEventDetails details = MouseEventDetailsBuilder
+                .buildMouseEventDetails(event.getCurrentGwtEvent(),
+                        getElement());
+        event.getDropDetails().put(Constants.DROP_DETAIL_MOUSE_EVENT,
+                details.serialize());
+    }
+
+    /**
+     * Empasises the drop location of the component when hovering over a
+     * ĆhildComponentContainer. Passing null as the container removes any
+     * previous emphasis.
+     * 
+     * @param container
+     *            The container which we are hovering over
+     * @param event
+     *            The drag event
+     */
+    protected void emphasis(Widget container, VDragEvent event) {
+
+        // Remove emphasis from previous hovers
+        deEmphasis();
+
+        // validate container
+        if (container == null
+                || !getElement().isOrHasChild(container.getElement())) {
+            return;
+        }
+
+        currentlyEmphasised = container;
+
+        VerticalDropLocation location = null;
+
+        // Add drop location specific style
+        if (currentlyEmphasised != this) {
+            location = getVerticalDropLocation(currentlyEmphasised, event);
+
+        } else {
+            location = VerticalDropLocation.MIDDLE;
+        }
+
+        UIObject.setStyleName(currentlyEmphasised.getElement(), OVER, true);
+        UIObject.setStyleName(currentlyEmphasised.getElement(),
+                OVER + "-" + location.toString().toLowerCase(), true);
+    }
+
+    /**
+     * Returns the current drag mode which determines how the drag is visualized
+     */
+    public LayoutDragMode getDragMode() {
+        return ddMouseHandler.getDragMode();
+    }
+
+    /**
+     * A hook for extended components to post process the the drop before it is
+     * sent to the server. Useful if you don't want to override the whole drop
+     * handler.
+     */
+    protected boolean postDropHook(VDragEvent drag) {
+        // Extended classes can add content here...
+        return true;
+    }
+
+    /**
+     * A hook for extended components to post process the the enter event.
+     * Useful if you don't want to override the whole drophandler.
+     */
+    protected void postEnterHook(VDragEvent drag) {
+        // Extended classes can add content here...
+    }
+
+    /**
+     * A hook for extended components to post process the the leave event.
+     * Useful if you don't want to override the whole drophandler.
+     */
+    protected void postLeaveHook(VDragEvent drag) {
+        // Extended classes can add content here...
+    }
+
+    /**
+     * A hook for extended components to post process the the over event. Useful
+     * if you don't want to override the whole drophandler.
+     */
+    protected void postOverHook(VDragEvent drag) {
+        // Extended classes can add content here...
+    }
+
+    /**
+     * Can be used to listen to drag start events, must return true for the drag
+     * to commence. Return false to interrupt the drag:
+     */
+    @Override
+    public boolean dragStart(Widget widget, LayoutDragMode mode) {
+        ComponentConnector layout = Util.findConnectorFor(this);
+        return VDragDropUtil.isDraggingEnabled(layout, widget);
+    }
+
+    /**
+     * Get the drop handler attached to the Layout
+     */
+    public VDDVerticalLayoutDropHandler getDropHandler() {
+        return dropHandler;
+    }
+
+    public void setDropHandler(VDDVerticalLayoutDropHandler dropHandler) {
+        this.dropHandler = dropHandler;
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see fi.jasoft.dragdroplayouts.client.ui.interfaces.VHasDragFilter#
+     * getDragFilter ()
+     */
+    public VDragFilter getDragFilter() {
+        return dragFilter;
+    }
+
+    IframeCoverUtility getIframeCoverUtility() {
+        return iframeCoverUtility;
+    }
+
+    @Override
+    public void setDragFilter(VDragFilter filter) {
+        this.dragFilter = filter;
+    }
+
+    public void setCellTopBottomDropRatio(float cellTopBottomDropRatio) {
+        this.cellTopBottomDropRatio = cellTopBottomDropRatio;
+    }
+
+    public float getCellTopBottomDropRatio() {
+        return cellTopBottomDropRatio;
+    }
+
+    @Override
+    public void iframeShimsEnabled(boolean enabled) {
+        iframeCovers = enabled;
+        iframeCoverUtility.setIframeCoversEnabled(enabled, getElement(), mode);
+    }
+
+    @Override
+    public boolean isIframeShimsEnabled() {
+        return iframeCovers;
+    }
+
+    @Override
+    public void setDragMode(LayoutDragMode mode) {
+        this.mode = mode;
+        ddMouseHandler.updateDragMode(mode);
+        iframeShimsEnabled(iframeCovers);
+    }
+
+    @Override
+    public void setDragImageProvider(VDragImageProvider provider) {
+        ddMouseHandler.setDragImageProvider(provider);
+    }
+
+    protected final VLayoutDragDropMouseHandler getMouseHandler() {
+        return ddMouseHandler;
+    }
+}

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/v7/client/ui/verticallayout/VDDVerticalLayoutDropHandler.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/v7/client/ui/verticallayout/VDDVerticalLayoutDropHandler.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2015 John Ahlroos
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package fi.jasoft.dragdroplayouts.v7.client.ui.verticallayout;
+
+import com.google.gwt.dom.client.Element;
+import com.google.gwt.dom.client.NativeEvent;
+import com.google.gwt.user.client.ui.Widget;
+import com.vaadin.client.ComponentConnector;
+import com.vaadin.client.WidgetUtil;
+import com.vaadin.client.ui.dd.VAcceptCallback;
+import com.vaadin.client.ui.dd.VDragEvent;
+import com.vaadin.client.ui.orderedlayout.Slot;
+import com.vaadin.client.ui.orderedlayout.VAbstractOrderedLayout;
+
+import fi.jasoft.dragdroplayouts.client.ui.VDDAbstractOrderedLayoutDropHandler;
+import fi.jasoft.dragdroplayouts.client.ui.VDragDropUtil;
+
+public class VDDVerticalLayoutDropHandler
+        extends VDDAbstractOrderedLayoutDropHandler<VDDVerticalLayout> {
+
+    public VDDVerticalLayoutDropHandler(ComponentConnector connector) {
+        super(connector);
+    }
+
+    @Override
+    protected void dragAccepted(VDragEvent drag) {
+        dragOver(drag);
+    }
+
+    @Override
+    public boolean drop(VDragEvent drag) {
+
+        // Un-emphasis any selections
+        getLayout().emphasis(null, null);
+
+        // Update the details
+        Widget slot = getSlot(drag.getElementOver(), drag.getCurrentGwtEvent());
+        getLayout().updateDragDetails(slot, drag);
+
+        return getLayout().postDropHook(drag) && super.drop(drag);
+    };
+
+    @Override
+    protected Slot getSlot(Element e, NativeEvent event) {
+        Slot slot = null;
+        if (getLayout().getElement() == e) {
+            // Most likely between components, use the closest one in that case
+            slot = findSlotVertically(12, event);
+        } else {
+            slot = WidgetUtil.findWidget(e, Slot.class);
+            if (slot == null) {
+                return null;
+            }
+            VAbstractOrderedLayout layout = VDragDropUtil.getSlotLayout(slot);
+            while (layout != getLayout() && getLayout().getElement()
+                    .isOrHasChild(e.getParentElement())) {
+                e = e.getParentElement();
+                slot = WidgetUtil.findWidget(e, Slot.class);
+                if (slot == null) {
+                    return null;
+                }
+                layout = VDragDropUtil.getSlotLayout(slot);
+            }
+        }
+        return slot;
+    }
+
+    @Override
+    public void dragOver(VDragEvent drag) {
+
+        // Remove any emphasis
+        getLayout().emphasis(null, null);
+
+        // Update the dropdetails so we can validate the drop
+        Slot slot = getSlot(drag.getElementOver(), drag.getCurrentGwtEvent());
+
+        if (slot != null) {
+            getLayout().updateDragDetails(slot, drag);
+        } else {
+            getLayout().updateDragDetails(getLayout(), drag);
+        }
+
+        getLayout().postOverHook(drag);
+
+        // Validate the drop
+        validate(new VAcceptCallback() {
+            public void accepted(VDragEvent event) {
+                Slot slot = getSlot(event.getElementOver(),
+                        event.getCurrentGwtEvent());
+                if (slot != null) {
+                    getLayout().emphasis(slot, event);
+                } else {
+                    getLayout().emphasis(getLayout(), event);
+                }
+            }
+        }, drag);
+    }
+
+    @Override
+    public void dragEnter(VDragEvent drag) {
+        super.dragEnter(drag);
+        Slot slot = getSlot(drag.getElementOver(), drag.getCurrentGwtEvent());
+        if (slot != null) {
+            getLayout().updateDragDetails(slot, drag);
+        } else {
+            getLayout().updateDragDetails(getLayout(), drag);
+        }
+        getLayout().postEnterHook(drag);
+    }
+
+    @Override
+    public void dragLeave(VDragEvent drag) {
+        getLayout().emphasis(null, drag);
+
+        getLayout().postLeaveHook(drag);
+    };
+
+}

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/v7/drophandlers/DefaultHorizontalLayoutDropHandler.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/v7/drophandlers/DefaultHorizontalLayoutDropHandler.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright 2015 John Ahlroos
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package fi.jasoft.dragdroplayouts.v7.drophandlers;
+
+import com.vaadin.event.dd.DragAndDropEvent;
+import com.vaadin.shared.ui.dd.HorizontalDropLocation;
+import com.vaadin.ui.AbstractOrderedLayout;
+import com.vaadin.ui.Alignment;
+import com.vaadin.ui.Component;
+import com.vaadin.ui.ComponentContainer;
+import com.vaadin.v7.ui.HorizontalLayout;
+import com.vaadin.ui.SingleComponentContainer;
+
+import fi.jasoft.dragdroplayouts.v7.DDHorizontalLayout
+        .HorizontalLayoutTargetDetails;
+import fi.jasoft.dragdroplayouts.drophandlers.AbstractDefaultLayoutDropHandler;
+import fi.jasoft.dragdroplayouts.events.LayoutBoundTransferable;
+
+/**
+ * A default drop handler for horizontal layouts
+ * 
+ * @author John Ahlroos / www.jasoft.fi
+ * @since 0.6.0
+ */
+@SuppressWarnings("serial")
+public class DefaultHorizontalLayoutDropHandler
+        extends AbstractDefaultLayoutDropHandler {
+
+    private Alignment dropAlignment;
+
+    /**
+     * Constructor
+     */
+    public DefaultHorizontalLayoutDropHandler() {
+
+    }
+
+    /**
+     * Constructor
+     * 
+     * @param dropCellAlignment
+     *            The cell alignment of the component after it has been dropped
+     */
+    public DefaultHorizontalLayoutDropHandler(Alignment dropCellAlignment) {
+        this.dropAlignment = dropCellAlignment;
+    }
+
+    /**
+     * Called when a component changed location within the layout
+     * 
+     * @param event
+     *            The drag and drop event
+     */
+    @Override
+    protected void handleComponentReordering(DragAndDropEvent event) {
+        // Component re-ordering
+        LayoutBoundTransferable transferable = (LayoutBoundTransferable) event
+                .getTransferable();
+        HorizontalLayoutTargetDetails details = (HorizontalLayoutTargetDetails) event
+                .getTargetDetails();
+        AbstractOrderedLayout layout = (AbstractOrderedLayout) details
+                .getTarget();
+        Component comp = transferable.getComponent();
+        int idx = details.getOverIndex();
+        int oldIndex = layout.getComponentIndex(comp);
+
+        if (idx == oldIndex) {
+            // Index did not change
+            return;
+        }
+
+        // Detach
+        layout.removeComponent(comp);
+
+        // Account for detachment if new index is bigger then old index
+        if (idx > oldIndex) {
+            idx--;
+        }
+
+        // Increase index if component is dropped after or above a previous
+        // component
+        HorizontalDropLocation loc = details.getDropLocation();
+        if (loc == HorizontalDropLocation.CENTER
+                || loc == HorizontalDropLocation.RIGHT) {
+            idx++;
+        }
+
+        // Add component
+        if (idx >= 0) {
+            layout.addComponent(comp, idx);
+        } else {
+            layout.addComponent(comp, 0);
+        }
+
+        // Add component alignment if given
+        if (dropAlignment != null) {
+            layout.setComponentAlignment(comp, dropAlignment);
+        }
+    }
+
+    /**
+     * Handle a drop from another layout
+     * 
+     * @param event
+     *            The drag and drop event
+     */
+    @Override
+    protected void handleDropFromLayout(DragAndDropEvent event) {
+        LayoutBoundTransferable transferable = (LayoutBoundTransferable) event
+                .getTransferable();
+        HorizontalLayoutTargetDetails details = (HorizontalLayoutTargetDetails) event
+                .getTargetDetails();
+        AbstractOrderedLayout layout = (AbstractOrderedLayout) details
+                .getTarget();
+        Component source = event.getTransferable().getSourceComponent();
+        int idx = (details).getOverIndex();
+        Component comp = transferable.getComponent();
+
+        // Check that we are not dragging an outer layout into an inner
+        // layout
+        Component parent = layout.getParent();
+        while (parent != null) {
+            if (parent == comp) {
+                return;
+            }
+            parent = parent.getParent();
+        }
+
+        // Detach from old source
+        if (source instanceof ComponentContainer) {
+            ((ComponentContainer) source).removeComponent(comp);
+        } else if (source instanceof SingleComponentContainer) {
+            ((SingleComponentContainer) source).setContent(null);
+        }
+
+        // Increase index if component is dropped after or above a
+        // previous
+        // component
+        HorizontalDropLocation loc = (details).getDropLocation();
+        if (loc == HorizontalDropLocation.CENTER
+                || loc == HorizontalDropLocation.RIGHT) {
+            idx++;
+        }
+
+        // Add component
+        if (idx >= 0) {
+            layout.addComponent(comp, idx);
+        } else {
+            layout.addComponent(comp);
+        }
+
+        // Add component alignment if given
+        if (dropAlignment != null) {
+            layout.setComponentAlignment(comp, dropAlignment);
+        }
+    }
+
+    @Override
+    protected void handleHTML5Drop(DragAndDropEvent event) {
+        LayoutBoundTransferable transferable = (LayoutBoundTransferable) event
+                .getTransferable();
+        HorizontalLayoutTargetDetails details = (HorizontalLayoutTargetDetails) event
+                .getTargetDetails();
+        AbstractOrderedLayout layout = (AbstractOrderedLayout) details
+                .getTarget();
+        Component source = event.getTransferable().getSourceComponent();
+        int idx = (details).getOverIndex();
+
+        // Increase index if component is dropped after or above a
+        // previous component
+        HorizontalDropLocation loc = (details).getDropLocation();
+        if (loc == HorizontalDropLocation.CENTER
+                || loc == HorizontalDropLocation.RIGHT) {
+            idx++;
+        }
+
+        Component comp = resolveComponentFromHTML5Drop(event);
+
+        // Add component
+        if (idx >= 0) {
+            layout.addComponent(comp, idx);
+        } else {
+            layout.addComponent(comp);
+        }
+
+        // Add component alignment if given
+        if (dropAlignment != null) {
+            layout.setComponentAlignment(comp, dropAlignment);
+        }
+    }
+
+    @Override
+    public Class<HorizontalLayout> getTargetLayoutType() {
+        return HorizontalLayout.class;
+    }
+}

--- a/addon/src/main/java/fi/jasoft/dragdroplayouts/v7/drophandlers/DefaultVerticalLayoutDropHandler.java
+++ b/addon/src/main/java/fi/jasoft/dragdroplayouts/v7/drophandlers/DefaultVerticalLayoutDropHandler.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2015 John Ahlroos
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package fi.jasoft.dragdroplayouts.v7.drophandlers;
+
+import com.vaadin.event.dd.DragAndDropEvent;
+import com.vaadin.shared.ui.dd.VerticalDropLocation;
+import com.vaadin.ui.AbstractOrderedLayout;
+import com.vaadin.ui.Alignment;
+import com.vaadin.ui.Component;
+import com.vaadin.ui.ComponentContainer;
+import com.vaadin.ui.SingleComponentContainer;
+import com.vaadin.v7.ui.VerticalLayout;
+
+import fi.jasoft.dragdroplayouts.v7.DDVerticalLayout
+        .VerticalLayoutTargetDetails;
+import fi.jasoft.dragdroplayouts.drophandlers
+        .AbstractDefaultLayoutDropHandler;
+import fi.jasoft.dragdroplayouts.events.LayoutBoundTransferable;
+
+/**
+ * A default drop handler for vertical layouts
+ * 
+ * @author John Ahlroos / www.jasoft.fi
+ * @since 0.6.0
+ */
+@SuppressWarnings("serial")
+public class DefaultVerticalLayoutDropHandler
+        extends AbstractDefaultLayoutDropHandler {
+
+    private Alignment dropAlignment;
+
+    /**
+     * Constructor
+     */
+    public DefaultVerticalLayoutDropHandler() {
+
+    }
+
+    /**
+     * Constructor
+     * 
+     * @param dropCellAlignment
+     *            The cell alignment of the component after it has been dropped
+     */
+    public DefaultVerticalLayoutDropHandler(Alignment dropCellAlignment) {
+        this.dropAlignment = dropCellAlignment;
+    }
+
+    /**
+     * Called when a component changed location within the layout
+     * 
+     * @param event
+     *            The drag and drop event
+     */
+    @Override
+    protected void handleComponentReordering(DragAndDropEvent event) {
+        // Component re-ordering
+        LayoutBoundTransferable transferable = (LayoutBoundTransferable) event
+                .getTransferable();
+        VerticalLayoutTargetDetails details = (VerticalLayoutTargetDetails) event
+                .getTargetDetails();
+        AbstractOrderedLayout layout = (AbstractOrderedLayout) details
+                .getTarget();
+        Component comp = transferable.getComponent();
+        int idx = details.getOverIndex();
+        int oldIndex = layout.getComponentIndex(comp);
+
+        if (idx == oldIndex) {
+            // Index did not change
+            return;
+        }
+
+        // Detach
+        layout.removeComponent(comp);
+
+        // Account for detachment if new index is bigger then old index
+        if (idx > oldIndex) {
+            idx--;
+        }
+
+        // Increase index if component is dropped after or above a previous
+        // component
+        VerticalDropLocation loc = details.getDropLocation();
+        if (loc == VerticalDropLocation.MIDDLE
+                || loc == VerticalDropLocation.BOTTOM) {
+            idx++;
+        }
+
+        // Add component
+        if (idx >= 0) {
+            layout.addComponent(comp, idx);
+        } else {
+            layout.addComponent(comp);
+        }
+
+        // Add component alignment if given
+        if (dropAlignment != null) {
+            layout.setComponentAlignment(comp, dropAlignment);
+        }
+
+    }
+
+    /**
+     * Handle a drop from another layout
+     * 
+     * @param event
+     *            The drag and drop event
+     */
+    @Override
+    protected void handleDropFromLayout(DragAndDropEvent event) {
+        LayoutBoundTransferable transferable = (LayoutBoundTransferable) event
+                .getTransferable();
+        VerticalLayoutTargetDetails details = (VerticalLayoutTargetDetails) event
+                .getTargetDetails();
+        AbstractOrderedLayout layout = (AbstractOrderedLayout) details
+                .getTarget();
+        Component source = event.getTransferable().getSourceComponent();
+        int idx = (details).getOverIndex();
+        Component comp = transferable.getComponent();
+
+        // Check that we are not dragging an outer layout into an inner
+        // layout
+        Component parent = layout.getParent();
+        while (parent != null) {
+            if (parent == comp) {
+                return;
+            }
+            parent = parent.getParent();
+        }
+
+        // Detach from old source
+        if (source instanceof ComponentContainer) {
+            ((ComponentContainer) source).removeComponent(comp);
+        } else if (source instanceof SingleComponentContainer) {
+            ((SingleComponentContainer) source).setContent(null);
+        }
+
+        // Increase index if component is dropped after or above a
+        // previous
+        // component
+        VerticalDropLocation loc = (details).getDropLocation();
+        if (loc == VerticalDropLocation.MIDDLE
+                || loc == VerticalDropLocation.BOTTOM) {
+            idx++;
+        }
+
+        // Add component
+        if (idx >= 0) {
+            layout.addComponent(comp, idx);
+        } else {
+            layout.addComponent(comp);
+        }
+
+        // Add component alignment if given
+        if (dropAlignment != null) {
+            layout.setComponentAlignment(comp, dropAlignment);
+        }
+    }
+
+    @Override
+    protected void handleHTML5Drop(DragAndDropEvent event) {
+        VerticalLayoutTargetDetails details = (VerticalLayoutTargetDetails) event
+                .getTargetDetails();
+        AbstractOrderedLayout layout = (AbstractOrderedLayout) details
+                .getTarget();
+        int idx = (details).getOverIndex();
+
+        // Increase index if component is dropped after or above a
+        // previous
+        // component
+        VerticalDropLocation loc = (details).getDropLocation();
+        if (loc == VerticalDropLocation.MIDDLE
+                || loc == VerticalDropLocation.BOTTOM) {
+            idx++;
+        }
+
+        Component comp = resolveComponentFromHTML5Drop(event);
+
+        // Add component
+        if (idx >= 0) {
+            layout.addComponent(comp, idx);
+        } else {
+            layout.addComponent(comp);
+        }
+
+        // Add component alignment if given
+        if (dropAlignment != null) {
+            layout.setComponentAlignment(comp, dropAlignment);
+        }
+
+    }
+
+    @Override
+    public Class<VerticalLayout> getTargetLayoutType() {
+        return VerticalLayout.class;
+    }
+}

--- a/demo/src/main/java/fi/jasoft/dragdroplayouts/demo/DemoUI.java
+++ b/demo/src/main/java/fi/jasoft/dragdroplayouts/demo/DemoUI.java
@@ -52,6 +52,7 @@ import fi.jasoft.dragdroplayouts.demo.views.DragdropHorizontalSplitPanelDemo;
 import fi.jasoft.dragdroplayouts.demo.views.DragdropLayoutDraggingDemo;
 import fi.jasoft.dragdroplayouts.demo.views.DragdropPanelDemo;
 import fi.jasoft.dragdroplayouts.demo.views.DragdropTabsheetDemo;
+import fi.jasoft.dragdroplayouts.demo.views.DragdropV7VerticalLayoutDemo;
 import fi.jasoft.dragdroplayouts.demo.views.DragdropVerticalLayoutDemo;
 import fi.jasoft.dragdroplayouts.demo.views.DragdropVerticalSplitPanelDemo;
 
@@ -130,6 +131,8 @@ public class DemoUI extends UI {
 
             addView(new DragdropDragFilterDemo(navigator));
             addView(new DragdropCaptionModeDemo(navigator));
+
+            addView(new DragdropV7VerticalLayoutDemo(navigator));
 
             // addView(new DragdropIframeDragging(navigator));
 

--- a/demo/src/main/java/fi/jasoft/dragdroplayouts/demo/DemoUI.java
+++ b/demo/src/main/java/fi/jasoft/dragdroplayouts/demo/DemoUI.java
@@ -52,6 +52,7 @@ import fi.jasoft.dragdroplayouts.demo.views.DragdropHorizontalSplitPanelDemo;
 import fi.jasoft.dragdroplayouts.demo.views.DragdropLayoutDraggingDemo;
 import fi.jasoft.dragdroplayouts.demo.views.DragdropPanelDemo;
 import fi.jasoft.dragdroplayouts.demo.views.DragdropTabsheetDemo;
+import fi.jasoft.dragdroplayouts.demo.views.DragdropV7HorizontalLayoutDemo;
 import fi.jasoft.dragdroplayouts.demo.views.DragdropV7VerticalLayoutDemo;
 import fi.jasoft.dragdroplayouts.demo.views.DragdropVerticalLayoutDemo;
 import fi.jasoft.dragdroplayouts.demo.views.DragdropVerticalSplitPanelDemo;
@@ -133,6 +134,7 @@ public class DemoUI extends UI {
             addView(new DragdropCaptionModeDemo(navigator));
 
             addView(new DragdropV7VerticalLayoutDemo(navigator));
+            addView(new DragdropV7HorizontalLayoutDemo(navigator));
 
             // addView(new DragdropIframeDragging(navigator));
 

--- a/demo/src/main/java/fi/jasoft/dragdroplayouts/demo/views/DragdropV7HorizontalLayoutDemo.java
+++ b/demo/src/main/java/fi/jasoft/dragdroplayouts/demo/views/DragdropV7HorizontalLayoutDemo.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2015 John Ahlroos
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package fi.jasoft.dragdroplayouts.demo.views;
+
+import com.vaadin.navigator.Navigator;
+import com.vaadin.ui.Button;
+import com.vaadin.ui.Component;
+import com.vaadin.ui.Label;
+
+import fi.jasoft.dragdroplayouts.v7.DDHorizontalLayout;
+import fi.jasoft.dragdroplayouts.client.ui.LayoutDragMode;
+import fi.jasoft.dragdroplayouts.demo.DemoView;
+import fi.jasoft.dragdroplayouts.v7.drophandlers
+        .DefaultHorizontalLayoutDropHandler;
+
+@SuppressWarnings("serial")
+public class DragdropV7HorizontalLayoutDemo extends DemoView {
+
+  public static final String NAME = "dd-v7-horizontal-layout";
+
+  private static final float EQUAL_HORIZONTAL_RATIO = 0.3f;
+
+  public DragdropV7HorizontalLayoutDemo(Navigator navigator) {
+    super(navigator);
+  }
+
+  @Override
+  public Component getLayout() {
+    // start-source
+    final DDHorizontalLayout layout = new DDHorizontalLayout();
+    layout.setComponentHorizontalDropRatio(EQUAL_HORIZONTAL_RATIO);
+    layout.setDragMode(LayoutDragMode.CLONE);
+    layout.setDropHandler(new DefaultHorizontalLayoutDropHandler());
+
+    layout
+        .addComponent(new Label("These components are stacked horizontally, try reordering them"));
+    Button btn1 = new Button("Button 1");
+    btn1.setWidth("100px");
+    layout.addComponent(btn1);
+
+    Button btn2 = new Button("Button 2");
+    btn2.setWidth("150px");
+    layout.addComponent(btn2);
+
+    Button btn3 = new Button("Button 3");
+    btn3.setWidth("200px");
+    layout.addComponent(btn3);
+    // end-source
+    return layout;
+  }
+
+  @Override
+  public String getCaption() {
+    return "Horizontal layout (V7)";
+  }
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+}

--- a/demo/src/main/java/fi/jasoft/dragdroplayouts/demo/views/DragdropV7VerticalLayoutDemo.java
+++ b/demo/src/main/java/fi/jasoft/dragdroplayouts/demo/views/DragdropV7VerticalLayoutDemo.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2015 John Ahlroos
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package fi.jasoft.dragdroplayouts.demo.views;
+
+import com.vaadin.navigator.Navigator;
+import com.vaadin.ui.Button;
+import com.vaadin.ui.Component;
+import com.vaadin.ui.Label;
+
+import fi.jasoft.dragdroplayouts.v7.DDVerticalLayout;
+import fi.jasoft.dragdroplayouts.client.ui.LayoutDragMode;
+import fi.jasoft.dragdroplayouts.demo.DemoView;
+import fi.jasoft.dragdroplayouts.v7.drophandlers
+        .DefaultVerticalLayoutDropHandler;
+
+@SuppressWarnings("serial")
+public class DragdropV7VerticalLayoutDemo extends DemoView {
+
+  public static final String NAME = "dd-v7-vertical-layout";
+
+  private static final float EQUAL_VERTICAL_RATIO = 0.3f;
+
+  public DragdropV7VerticalLayoutDemo(Navigator navigator) {
+    super(navigator);
+  }
+
+  @Override
+  public Component getLayout() {
+    // start-source
+    final DDVerticalLayout layout = new DDVerticalLayout();
+    layout.setComponentVerticalDropRatio(EQUAL_VERTICAL_RATIO);
+    layout.setDragMode(LayoutDragMode.CLONE);
+    layout.setDropHandler(new DefaultVerticalLayoutDropHandler());
+
+    layout.addComponent(new Label("These components are stacked vertically, try reordering them"));
+    Button btn = new Button("Button 1");
+    btn.setWidth("100px");
+    layout.addComponent(btn);
+    btn = new Button("Button 2");
+    btn.setWidth("150px");
+    layout.addComponent(btn);
+    btn = new Button("Button 3");
+    btn.setWidth("200px");
+    layout.addComponent(btn);
+    // end-source
+    return layout;
+  }
+
+  @Override
+  public String getCaption() {
+    return "Vertical layout (V7)";
+  }
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+}


### PR DESCRIPTION
Add dragdroplayouts that extend com.vaadin.v7.HorizontalLayout and com.vaadin.v7.VerticalLayout under new package fi.jasoft.dragdroplayouts.v7.

The added dd layouts are just copies of their Vaadin 8 counterparts, but they extend the compatibility layouts instead of the Vaadin 8 layouts.

Demo application updated to include the added dd layouts.